### PR TITLE
Fix bug when threads != cpu_count

### DIFF
--- a/rulegen.py
+++ b/rulegen.py
@@ -919,7 +919,7 @@ class RuleGen:
 
         else:
             # Signal workers to stop.
-            for i in range(multiprocessing.cpu_count()):
+            for i in range(self.threads):
                 passwords_queue.put(None) 
 
            # Wait for all of the queued passwords to finish.


### PR DESCRIPTION
When using the --threads flag, the script doesn't end, because it is waiting for cpu_count() threads (which is never satisfied).